### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,16 @@
 language: php
 dist: trusty
 php:
-  - '5.6'
   - '7.0'
   - '7.1'
+  - '7.2'
+  - nightly
   - 'hhvm'
+matrix:
+  allow_failures:
+    - php: nightly
 install:
-  - composer update
+  - composer install
 script:
  - ./vendor/bin/phpunit --coverage-clover ./tests/Logs/clover.xml
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,17 @@
         "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^6.5",
         "php-coveralls/php-coveralls": "^2.1"
     },
     "autoload": {
         "psr-4": {
             "DivineOmega\\DOFileCache\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "DivineOmega\\DOFileCache\\Tests\\": "tests/"
         }
     },
     "extra": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -25,6 +25,6 @@
         </whitelist>
     </filter>
     <php>
-        
+
     </php>
 </phpunit>

--- a/tests/Functional/CacheStorageAndRetrievalTest.php
+++ b/tests/Functional/CacheStorageAndRetrievalTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace DivineOmega\DOFileCache\Tests;
+
 use PHPUnit\Framework\TestCase;
 
 final class CacheStorageAndRetrievalTest extends TestCase

--- a/tests/Unit/BasicTest.php
+++ b/tests/Unit/BasicTest.php
@@ -1,8 +1,10 @@
 <?php
 
+namespace DivineOmega\DOFileCache\Tests;
+
 use PHPUnit\Framework\TestCase;
 
-final class BasicTests extends TestCase
+final class BasicTest extends TestCase
 {
     private $cache = null;
 


### PR DESCRIPTION
# Changed log

- Remove `php-5.6` support because this version is not supported from official PHP.
- Upgrade the PHPUnit version.
- Using the `autoload-dev` in `composer.json` to define the related test classes namespace.